### PR TITLE
Change `repo-branch: master` to `main` for urls

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,7 +18,7 @@ book:
   #     theme: clean
   #     openSidebar: false
   repo-url: https://github.com/psyteachr/intro-r-pkgs/
-  repo-branch: master
+  repo-branch: main
   repo-actions: [edit, issue, source]
 #  downloads: [pdf, epub]
   sharing: [twitter, facebook, linkedin]


### PR DESCRIPTION
Thank you for the book and the playlist; they are great!🙏

### Problem

The branch name of the repo is "main" but urls are created according to the default branch name "master" as mentioned at quarto-dev/quarto-cli#4826. Because "Edit this page" and "View source" buttons in every page contains branch names in their urls, they do not work now.

The GIF of the problem:

![master_to_main](https://github.com/PsyTeachR/intro-r-pkgs/assets/40212849/04ce9a67-5656-424d-b71a-a027e656be75)

---

### Solution

It updates `repo-branch: master` to `repo-branch: main` to solve this.